### PR TITLE
Add support for Laravel Echo

### DIFF
--- a/js/request.js
+++ b/js/request.js
@@ -46,6 +46,7 @@ async function sendRequestToServer() {
             headers: {
                 'Content-type': 'application/json',
                 'X-Livewire': '',
+                'X-Socket-Id': Echo?.socketId(),
             },
         }
 


### PR DESCRIPTION
Laravel Echo exposes a socket ID. This socket ID is mandatory when using `broadcast(...)->toOthers()`. During my test, the mandatory `X-Socket-Id` is not injected automatically by `fetch`, so we need to add it when available.

Temporarily, you can make it work by adding the following code to your JS code:

```js
document.addEventListener('livewire:init', () => {
    Livewire.hook('request', ({ options }) => {
        options.headers["X-Socket-Id"] = Echo?.socketId();
    })
})
```